### PR TITLE
Fixed bug that caused NullPointerException with custom training data

### DIFF
--- a/src/edu/msu/cme/rdp/multicompare/MultiClassifier.java
+++ b/src/edu/msu/cme/rdp/multicompare/MultiClassifier.java
@@ -63,7 +63,7 @@ public class MultiClassifier {
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
-        if ( gene.equalsIgnoreCase(ClassifierFactory.FUNGALITS_warcup_GENE) ){
+        if ( gene != null && gene.equalsIgnoreCase(ClassifierFactory.FUNGALITS_warcup_GENE) ){
             ranks = ClassificationResultFormatter.RANKS_WITHSPECIES;
         }
     }


### PR DESCRIPTION
Added != null condition to gene comparison in MultiClassifier.java
Otherwise classification with own training sets resulted in a NullPointerException.
This was due to the unspecified -g option (which is not possible in conjunction with -t):
java -Xmx4000M -jar /software/RDPTools/classifier.jar classify --train_propfile=trained.properties --outputFile=out.txt --format=allrank --queryFile=query.fastq
Exception in thread "main" java.lang.NullPointerException
        at edu.msu.cme.rdp.multicompare.MultiClassifier.<init>(MultiClassifier.java:66)
        at edu.msu.cme.rdp.multicompare.MultiClassifier.<init>(MultiClassifier.java:72)
        at edu.msu.cme.rdp.multicompare.Main.main(Main.java:245)
        at edu.msu.cme.rdp.classifier.cli.ClassifierMain.main(ClassifierMain.java:65)
The additional condition should have no negative side effects.
